### PR TITLE
Move näytä vetäjät button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,9 @@
   <label>Vetäjä<input name="vetaja" id="vetaja" placeholder="VETÄJÄN NIMI"></label>
   <button id="leuka">LEUKA!</button>
 </form>
+<a href="#" id="toggle" class="center-link">Näytä vetäjät</a>
 <div id="iso"></div>
 <div id="leuat"></div>
-<a href="#" id="toggle">Näytä vetäjät</a>
 <script src="/socket.io/socket.io.js"></script>
 <script src="Bacon.js"></script>
 <script src="jquery.js"></script>

--- a/public/leuat.css
+++ b/public/leuat.css
@@ -141,6 +141,11 @@ body.show-muutos .muutos.score-toggle {
 .team:nth-child(odd) {
    background-color: #eee;
 }
+.center-link {
+  display: flex;
+  justify-content: center;
+}
+
 #iso {
 position: absolute;
 font-size: 4em;


### PR DESCRIPTION
Näytä vetäjät -nappi on aikaisemmin ollut ikävästi sivun alareunassa. Ehdotan, että siirretään nappi sivun yläreunaan, niin se on helpommin saatavilla.